### PR TITLE
Fix Difference Calculation in Bar Chart

### DIFF
--- a/lib/history.dart
+++ b/lib/history.dart
@@ -248,7 +248,7 @@ class _HistoryState extends State<History> {
                                     barRods: [
                                       BarChartRodData(
                                         toY: (snapshot.data![index]
-                                                    .activeEnergyBurned -
+                                                    .dietaryEnergyConsumed -
                                                 snapshot.data![index]
                                                     .activeEnergyBurned -
                                                 snapshot.data![index]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.1+2
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
The calculation of the difference between the burned and consumed energy was wrong in the bar chart. This is now fixed by using the correct formular to calculate the difference.