### PR TITLE
Adjust Date Formatting for `sixmonths` and `year` Scope

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -70,9 +70,9 @@ extension HistoryScopeExtension on HistoryScope {
       case HistoryScope.month:
         return DateFormat('dd.MM.yyyy').format(dateTime);
       case HistoryScope.sixmonths:
-        return '${DateFormat('dd.MM').format(dateTime.subtract(Duration(seconds: (toInterval() - 60))))} to ${DateFormat('dd.MM').format(dateTime)}';
+        return '${DateFormat('dd.MM').format(dateTime.subtract(Duration(seconds: (toInterval() - 1))))} to ${DateFormat('dd.MM').format(dateTime)}';
       case HistoryScope.year:
-        return '${DateFormat('dd.MM').format(dateTime.subtract(Duration(seconds: (toInterval() - 60))))} to ${DateFormat('dd.MM').format(dateTime)}';
+        return '${DateFormat('dd.MM').format(dateTime.subtract(Duration(seconds: (toInterval() - 1))))} to ${DateFormat('dd.MM').format(dateTime)}';
     }
   }
 }


### PR DESCRIPTION
To format the data for the `sixmonths` and `year` scope we substracted 60 seconds from the interval, because the interval end 23:59:59 and we wanted to display the next day as the start of the interval. Now we are just subtracting 1 second to achieve the same.