### PR TITLE
Add Tooltips

### DIFF
--- a/lib/history.dart
+++ b/lib/history.dart
@@ -265,6 +265,7 @@ class _HistoryState extends State<History> {
                                 }),
                                 barTouchData: BarTouchData(
                                   touchTooltipData: BarTouchTooltipData(
+                                    tooltipPadding: const EdgeInsets.all(8),
                                     fitInsideHorizontally: true,
                                     fitInsideVertically: true,
                                     getTooltipColor: (BarChartGroupData group) {
@@ -304,7 +305,7 @@ class _HistoryState extends State<History> {
                                           ),
                                           TextSpan(
                                             text:
-                                                'Difference: ${snapshot.data![group.x.toInt()].activeEnergyBurned + snapshot.data![group.x.toInt()].basalEnergyBurned - snapshot.data![group.x.toInt()].dietaryEnergyConsumed}\n',
+                                                'Difference: ${snapshot.data![group.x.toInt()].activeEnergyBurned + snapshot.data![group.x.toInt()].basalEnergyBurned - snapshot.data![group.x.toInt()].dietaryEnergyConsumed}',
                                             style: const TextStyle(
                                               color: Color(0xff00fff7),
                                               fontSize: 12,
@@ -455,33 +456,45 @@ class _HistoryState extends State<History> {
                                         ),
                                       ),
                                       TableCell(
-                                        child: Text(
-                                          '${snapshot.data![index].activeEnergyBurned + snapshot.data![index].basalEnergyBurned}',
-                                          style: const TextStyle(
-                                            color: Color(0xfff9104f),
-                                            fontSize: 12,
+                                        child: Tooltip(
+                                          message:
+                                              'Active Energy: ${snapshot.data![index].activeEnergyBurned} kcal\nBasal Energy: ${snapshot.data![index].basalEnergyBurned} kcal',
+                                          child: Text(
+                                            '${snapshot.data![index].activeEnergyBurned + snapshot.data![index].basalEnergyBurned}',
+                                            style: const TextStyle(
+                                              color: Color(0xfff9104f),
+                                              fontSize: 12,
+                                            ),
+                                            textAlign: TextAlign.center,
                                           ),
-                                          textAlign: TextAlign.center,
                                         ),
                                       ),
                                       TableCell(
-                                        child: Text(
-                                          '${snapshot.data![index].dietaryEnergyConsumed}',
-                                          style: const TextStyle(
-                                            color: Color(0xffa7fe01),
-                                            fontSize: 12,
+                                        child: Tooltip(
+                                          message:
+                                              'Dietary Energy: ${snapshot.data![index].dietaryEnergyConsumed} kcal',
+                                          child: Text(
+                                            '${snapshot.data![index].dietaryEnergyConsumed}',
+                                            style: const TextStyle(
+                                              color: Color(0xffa7fe01),
+                                              fontSize: 12,
+                                            ),
+                                            textAlign: TextAlign.center,
                                           ),
-                                          textAlign: TextAlign.center,
                                         ),
                                       ),
                                       TableCell(
-                                        child: Text(
-                                          '${snapshot.data![index].activeEnergyBurned + snapshot.data![index].basalEnergyBurned - snapshot.data![index].dietaryEnergyConsumed}',
-                                          style: const TextStyle(
-                                            color: Color(0xff00fff7),
-                                            fontSize: 12,
+                                        child: Tooltip(
+                                          message:
+                                              'Difference: ${snapshot.data![index].activeEnergyBurned + snapshot.data![index].basalEnergyBurned - snapshot.data![index].dietaryEnergyConsumed} kcal',
+                                          child: Text(
+                                            '${snapshot.data![index].activeEnergyBurned + snapshot.data![index].basalEnergyBurned - snapshot.data![index].dietaryEnergyConsumed}',
+                                            style: const TextStyle(
+                                              color: Color(0xff00fff7),
+                                              fontSize: 12,
+                                            ),
+                                            textAlign: TextAlign.center,
                                           ),
-                                          textAlign: TextAlign.center,
                                         ),
                                       ),
                                     ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,32 +17,41 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TooltipVisibility(
-      visible: false,
-      child: MaterialApp(
-        title: 'Energy Diff',
-        theme: ThemeData(
-          useMaterial3: true,
-          colorScheme: const ColorScheme(
-            brightness: Brightness.dark,
-            primary: Color(0xff171f2c),
-            onPrimary: Colors.white,
-            secondary: Color(0xff171f2c),
-            onSecondary: Colors.white,
-            error: Colors.red,
-            onError: Colors.white,
-            surface: Color(0xff171f2c),
-            onSurface: Colors.white,
+    return MaterialApp(
+      title: 'Energy Diff',
+      theme: ThemeData(
+        useMaterial3: true,
+        colorScheme: const ColorScheme(
+          brightness: Brightness.dark,
+          primary: Color(0xff171f2c),
+          onPrimary: Colors.white,
+          secondary: Color(0xff171f2c),
+          onSecondary: Colors.white,
+          error: Colors.red,
+          onError: Colors.white,
+          surface: Color(0xff171f2c),
+          onSurface: Colors.white,
+        ),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Color(0xff171f2c),
+          foregroundColor: Colors.white,
+          elevation: 0,
+        ),
+        tooltipTheme: const TooltipThemeData(
+          padding: EdgeInsets.all(8),
+          preferBelow: false,
+          textStyle: TextStyle(
+            color: Colors.white,
+            fontSize: 12,
           ),
-          appBarTheme: const AppBarTheme(
-            backgroundColor: Color(0xff171f2c),
-            foregroundColor: Colors.white,
-            elevation: 0,
+          decoration: BoxDecoration(
+            color: Color(0xff171f2c),
+            borderRadius: BorderRadius.all(Radius.circular(4)),
           ),
         ),
-        debugShowCheckedModeBanner: false,
-        home: const Home(),
       ),
+      debugShowCheckedModeBanner: false,
+      home: const Home(),
     );
   }
 }

--- a/lib/today.dart
+++ b/lib/today.dart
@@ -157,11 +157,15 @@ class _TodayState extends State<Today> {
                                   fontSize: 12,
                                 ),
                               ),
-                              Text(
-                                '${snapshot.data == null || snapshot.data!.isEmpty ? 0 : getData(snapshot.data!, HealthDataType.ACTIVE_ENERGY_BURNED) + getData(snapshot.data!, HealthDataType.BASAL_ENERGY_BURNED)} kcal',
-                                style: const TextStyle(
-                                  color: Color(0xfff9104f),
-                                  fontWeight: FontWeight.bold,
+                              Tooltip(
+                                message:
+                                    'Active Energy: ${getData(snapshot.data!, HealthDataType.ACTIVE_ENERGY_BURNED)} kcal\nBasal Energy: ${getData(snapshot.data!, HealthDataType.BASAL_ENERGY_BURNED)} kcal',
+                                child: Text(
+                                  '${snapshot.data == null || snapshot.data!.isEmpty ? 0 : getData(snapshot.data!, HealthDataType.ACTIVE_ENERGY_BURNED) + getData(snapshot.data!, HealthDataType.BASAL_ENERGY_BURNED)} kcal',
+                                  style: const TextStyle(
+                                    color: Color(0xfff9104f),
+                                    fontWeight: FontWeight.bold,
+                                  ),
                                 ),
                               ),
                             ],
@@ -177,11 +181,15 @@ class _TodayState extends State<Today> {
                                   fontSize: 12,
                                 ),
                               ),
-                              Text(
-                                '${snapshot.data == null || snapshot.data!.isEmpty ? 0 : getData(snapshot.data!, HealthDataType.DIETARY_ENERGY_CONSUMED)} kcal',
-                                style: const TextStyle(
-                                  color: Color(0xffa7fe01),
-                                  fontWeight: FontWeight.bold,
+                              Tooltip(
+                                message:
+                                    'Dietary Energy: ${getData(snapshot.data!, HealthDataType.DIETARY_ENERGY_CONSUMED)} kcal',
+                                child: Text(
+                                  '${snapshot.data == null || snapshot.data!.isEmpty ? 0 : getData(snapshot.data!, HealthDataType.DIETARY_ENERGY_CONSUMED)} kcal',
+                                  style: const TextStyle(
+                                    color: Color(0xffa7fe01),
+                                    fontWeight: FontWeight.bold,
+                                  ),
                                 ),
                               ),
                             ],
@@ -197,11 +205,15 @@ class _TodayState extends State<Today> {
                                   fontSize: 12,
                                 ),
                               ),
-                              Text(
-                                '${snapshot.data == null || snapshot.data!.isEmpty ? 0 : getData(snapshot.data!, HealthDataType.ACTIVE_ENERGY_BURNED) + getData(snapshot.data!, HealthDataType.BASAL_ENERGY_BURNED) - getData(snapshot.data!, HealthDataType.DIETARY_ENERGY_CONSUMED)} kcal',
-                                style: const TextStyle(
-                                  color: Color(0xff00fff7),
-                                  fontWeight: FontWeight.bold,
+                              Tooltip(
+                                message:
+                                    'Difference: ${getData(snapshot.data!, HealthDataType.ACTIVE_ENERGY_BURNED) + getData(snapshot.data!, HealthDataType.BASAL_ENERGY_BURNED) - getData(snapshot.data!, HealthDataType.DIETARY_ENERGY_CONSUMED)} kcal',
+                                child: Text(
+                                  '${snapshot.data == null || snapshot.data!.isEmpty ? 0 : getData(snapshot.data!, HealthDataType.ACTIVE_ENERGY_BURNED) + getData(snapshot.data!, HealthDataType.BASAL_ENERGY_BURNED) - getData(snapshot.data!, HealthDataType.DIETARY_ENERGY_CONSUMED)} kcal',
+                                  style: const TextStyle(
+                                    color: Color(0xff00fff7),
+                                    fontWeight: FontWeight.bold,
+                                  ),
                                 ),
                               ),
                             ],


### PR DESCRIPTION
Whenever we show the burned, consumed or difference energy, we now also show a tooltip. This was done so that we can show the active and basal energy for the burned energy.

This also fixes the tooltip for the bar chart, which contained an unnecessary new line after we displayed the difference.